### PR TITLE
Introduce jvmfmt plugin

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,6 +4,8 @@ val scala212 = "2.12.10"
 
 ThisBuild / version := "0.2.4-SNAPSHOT"
 
+val comp = "compile->compile"
+
 def commonSettings: SettingsDefinition =
   Def.settings(
     scalaVersion in ThisBuild := scala212,
@@ -59,7 +61,7 @@ val clangformat = project
     name := "sbt-clang-format",
     description := "Format source files using clang-format.",
   )
-  .dependsOn(lib % "compile->compile")
+  .dependsOn(lib % comp)
 
 val javaformat = project
   .enablePlugins(SbtPlugin)
@@ -69,7 +71,7 @@ val javaformat = project
     name := "sbt-java-format",
     description := "Format source files using javaformat.",
   )
-  .dependsOn(lib % "compile->compile")
+  .dependsOn(lib % comp)
 
 val scalaformat = project
   .enablePlugins(SbtPlugin)
@@ -81,8 +83,16 @@ val scalaformat = project
     name := "sbt-scala-format",
     description := "Format source files using scalafmt.",
   )
-  .dependsOn(lib % "compile->compile")
+  .dependsOn(lib % comp)
 
+val jvmformat = project
+  .enablePlugins(SbtPlugin)
+  .settings(
+    pluginSettings,
+    name := "sbt-jvm-format",
+    description := "Format jvm source files using scalafmt and javafmt.",
+  )
+  .dependsOn(lib % comp, javaformat % comp, scalaformat % comp)
 // The root project aggregates the library and three plugins via depends on
 val `sbt-source-format` = (project in file("."))
   .enablePlugins(SbtPlugin)
@@ -95,13 +105,8 @@ val `sbt-source-format` = (project in file("."))
     name := "sbt-source-format",
     description := "Format source files using clang-format, scalafmt and the google java format library.",
   )
-  .dependsOn(
-    lib % "compile->compile",
-    clangformat % "compile->compile",
-    javaformat % "compile->compile",
-    scalaformat % "compile->compile",
-  )
-  .aggregate(lib, clangformat, javaformat, scalaformat)
+  .dependsOn(lib % comp, clangformat % comp, jvmformat % comp)
+  .aggregate(lib, clangformat, javaformat, jvmformat, scalaformat)
 
 def release(local: Boolean): Def.Initialize[Task[Seq[Unit]]] = Def.taskDyn {
   val _ = (

--- a/javaformat/src/main/scala/com/swoval/format/JavafmtPlugin.scala
+++ b/javaformat/src/main/scala/com/swoval/format/JavafmtPlugin.scala
@@ -1,11 +1,11 @@
 package com.swoval.format
 
-import com.swoval.format.java.JavaFormatter
-import com.swoval.format.lib.SourceFormat
 import _root_.java.nio.file.Path
 
+import com.swoval.format.java.JavaFormatter
+import com.swoval.format.lib.{ ConcurrentRestriction, SourceFormat }
+import sbt.Keys.unmanagedSources
 import sbt._
-import Keys.{ concurrentRestrictions, unmanagedSources }
 import sbt.nio.Keys.inputFileStamps
 
 object JavafmtPlugin extends AutoPlugin with JavafmtKeys {
@@ -14,12 +14,10 @@ object JavafmtPlugin extends AutoPlugin with JavafmtKeys {
   private val javaFormatter = TaskKey[(Path, Logger) => String]("java-formatter", "", Int.MaxValue)
 
   private def javafmtOnCompileImpl(config: ConfigKey): Def.Initialize[Task[Unit]] =
-    Def.taskDyn(if ((javafmtOnCompile in config).value) javafmt in config else Def.task(()))
-  override lazy val globalSettings = Def.settings(
-    Global / concurrentRestrictions +=
-      Tags.limit(SourceFormat.tag, _root_.java.lang.Runtime.getRuntime.availableProcessors),
-    javafmtOnCompile := false,
-  )
+    Def.taskDyn(
+      if ((javafmtOnCompile in config).?.value.getOrElse(false)) javafmt in config else Def.task(())
+    )
+  override lazy val globalSettings = Def.settings(ConcurrentRestriction.addLimit)
   override lazy val projectSettings = Def.settings(
     javaFormatter := JavaFormatter,
     SourceFormat.settings(

--- a/jvmformat/src/main/scala/com/swoval/format/JvmfmtPlugin.scala
+++ b/jvmformat/src/main/scala/com/swoval/format/JvmfmtPlugin.scala
@@ -1,0 +1,37 @@
+package com.swoval.format
+
+import com.swoval.format.lib.ConcurrentRestriction
+import sbt._
+
+object JvmPlugin extends AutoPlugin with JvmfmtKeys {
+  override def trigger = allRequirements
+  object autoImport extends JvmfmtKeys
+  import JavafmtPlugin._
+  import ScalafmtPlugin._
+
+  override lazy val globalSettings: Seq[Def.Setting[_]] = Def.settings(
+    ConcurrentRestriction.addLimit,
+    jvmfmtOnCompile := false,
+    javafmtOnCompile := (ThisBuild / jvmfmtOnCompile).value,
+    scalafmtOnCompile := (ThisBuild / jvmfmtOnCompile).value,
+  )
+  override lazy val projectSettings: Seq[Def.Setting[_]] = Def.settings(
+    Compile / jvmfmt := Seq(javafmt, scalafmt).map(Compile / _).join.value,
+    Test / jvmfmt := Seq(javafmt, scalafmt).map(Test / _).join.value,
+    Compile / jvmfmtCheck := Seq(javafmtCheck, scalafmtCheck).map(Compile / _).join.value,
+    Test / jvmfmtCheck := Seq(javafmtCheck, scalafmtCheck).map(Test / _).join.value,
+    jvmfmtAll := Seq(javafmtAll, scalafmtAll).join.value,
+    jvmfmtCheckAll := Seq(javafmtCheckAll, scalafmtCheckAll).join.value,
+  )
+}
+
+private[format] trait JvmfmtKeys {
+  val jvmfmt = taskKey[Unit]("Format source files using the google java formatter.")
+  val jvmfmtAll = taskKey[Unit]("Format all project source files using the google java formatter.")
+  val jvmfmtCheck =
+    taskKey[Unit]("Check source file formatting using the google java formatter.")
+  val jvmfmtCheckAll =
+    taskKey[Unit]("Check all project source file formatting using the google java formatter.")
+  val jvmfmtOnCompile =
+    settingKey[Boolean]("Toggles whether to perform formatting before compilation.")
+}

--- a/lib/src/main/scala/com/swoval/format/lib/ConcurrentRestriction.scala
+++ b/lib/src/main/scala/com/swoval/format/lib/ConcurrentRestriction.scala
@@ -1,0 +1,15 @@
+package com.swoval.format
+package lib
+
+import sbt.{ ConcurrentRestrictions, Def, SettingKey, Tags }
+import sbt.Keys.concurrentRestrictions
+
+private[format] object ConcurrentRestriction {
+  val tag = ConcurrentRestrictions.Tag("source-format")
+  val limit = Tags.limit(tag, 1)
+  val addLimit: Def.Setting[_] = sbt.Global / concurrentRestrictions ++= {
+    val prev = (sbt.Global / concurrentRestrictions).value
+    if (prev.contains(limit)) Nil else limit :: Nil
+  }
+  val parallelize = SettingKey[Boolean]("sourceFormatParallelize", "", Int.MaxValue)
+}

--- a/src/sbt-test/sbt-source-format/jvmfmt-all/.scalafmt.conf
+++ b/src/sbt-test/sbt-source-format/jvmfmt-all/.scalafmt.conf
@@ -1,0 +1,20 @@
+version = 2.3.2
+maxColumn = 100
+project.git = true
+
+# http://docs.scala-lang.org/style/scaladoc.html recommends the JavaDoc style.
+# scala/scala is written that way too https://github.com/scala/scala/blob/v2.12.2/src/library/scala/Predef.scala
+docstrings = JavaDoc
+
+# This also seems more idiomatic to include whitespace in import x.{ yyy }
+spaces.inImportCurlyBraces = true
+
+# This is more idiomatic Scala.
+# http://docs.scala-lang.org/style/indentation.html#methods-with-numerous-arguments
+align.openParenCallSite = false
+align.openParenDefnSite = false
+
+# For better code clarity
+danglingParentheses = true
+
+trailingCommas = preserve

--- a/src/sbt-test/sbt-source-format/jvmfmt-all/build.sbt
+++ b/src/sbt-test/sbt-source-format/jvmfmt-all/build.sbt
@@ -1,0 +1,15 @@
+import sbt.nio.FileStamper
+
+val check = inputKey[Unit]("")
+check := {
+  val changeCount = Def.spaceDelimited("").parsed.head.toInt
+  val changes = checkChanges.value
+  assert(
+    changes.modified.size == changeCount,
+    s"$changes had ${changes.modified.size} $changeCount modified files"
+  )
+}
+val checkChanges = taskKey[FileChanges]("")
+checkChanges := checkChanges.inputFileChanges
+checkChanges / inputFileStamper := FileStamper.Hash
+checkChanges / fileInputs := baseDirectory.value.toGlob / ** / "*.{sbt,java,scala}" :: Nil

--- a/src/sbt-test/sbt-source-format/jvmfmt-all/project/plugins.sbt
+++ b/src/sbt-test/sbt-source-format/jvmfmt-all/project/plugins.sbt
@@ -1,0 +1,3 @@
+addSbtPlugin(
+
+  "com.swoval" % "sbt-jvm-format" % "0.2.4-SNAPSHOT")

--- a/src/sbt-test/sbt-source-format/jvmfmt-all/src/main/java/Foo.java
+++ b/src/sbt-test/sbt-source-format/jvmfmt-all/src/main/java/Foo.java
@@ -1,0 +1,7 @@
+package com.swoval;
+
+public class Foo {
+  public static final
+  int CONSTANT =
+      1;
+}

--- a/src/sbt-test/sbt-source-format/jvmfmt-all/src/main/scala/Baz.scala
+++ b/src/sbt-test/sbt-source-format/jvmfmt-all/src/main/scala/Baz.scala
@@ -1,0 +1,7 @@
+object Baz {
+
+  val x =
+
+
+    3
+}

--- a/src/sbt-test/sbt-source-format/jvmfmt-all/src/test/java/Bar.java
+++ b/src/sbt-test/sbt-source-format/jvmfmt-all/src/test/java/Bar.java
@@ -1,0 +1,10 @@
+package com.swoval;
+
+class Bar {
+
+  final int X =
+
+
+
+      3;
+}

--- a/src/sbt-test/sbt-source-format/jvmfmt-all/src/test/scala/TestBaz.scala
+++ b/src/sbt-test/sbt-source-format/jvmfmt-all/src/test/scala/TestBaz.scala
@@ -1,0 +1,10 @@
+object TestBaz {
+
+
+
+
+
+  val x =
+
+    1
+}

--- a/src/sbt-test/sbt-source-format/jvmfmt-all/test
+++ b/src/sbt-test/sbt-source-format/jvmfmt-all/test
@@ -1,0 +1,9 @@
+-> jvmfmtCheckAll
+
+> check 0
+
+> jvmfmtAll
+
+> check 5
+
+> jvmfmtCheckAll


### PR DESCRIPTION
This plugin effectively aggregates the JavafmtPlugin and the
ScalafmtPlugin into a single plugin. The nice feature is that you can
run jvmfmtAll and it will format _all_ of the java, scala and sbt build
files in the project.